### PR TITLE
Split Tasks By Layer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 #storage_provider: "{{ some_default_service_or_toolset }}"
 device_type: "lvm"
 device_name: ""  # this can be UUID=<uuid>, /dev/disk/by-*, &c if existing
-size: "100%"
+size: "100%FREE"
 disks: []  # use the first unused disk by default, can be /dev/disk/by-*
 use_partitions: false
 
@@ -16,10 +16,10 @@ fs_overwrite_existing: true
 
 # mount
 mount_point: ""
-mount_options: ""
+mount_options: "defaults"
 mount_check: 0
 mount_passno: 0
-mount_state: "present"
+mount_state: "mounted"
 mount_device_identifier: "uuid"  # uuid|label|user
 
 # luks encryption
@@ -57,7 +57,7 @@ partition_flags: []
 # lvm
 lvm_type: "linear"
 lvm_vg: ""  # TODO: Select a good default. Hostname?
-lvm_vg_size: "max"
+lvm_vg_size: "max"  # "max", "min", or eg: "50G"
 lvm_pool: ""
 # Can the below be handled via generic 'lv_options' and 'vg_options'?
 #lvm_origin: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for template
 #storage_provider: "{{ some_default_service_or_toolset }}"
+storage_backend: "default"
+storage_layers: ["disklabel", "partitions", "vg", "lv", "fs", "mount"]  # luks, md, vdo
+state: "present"
 device_type: "lvm"
 device_name: ""  # this can be UUID=<uuid>, /dev/disk/by-*, &c if existing
 size: "100%FREE"
@@ -19,8 +22,7 @@ mount_point: ""
 mount_options: "defaults"
 mount_check: 0
 mount_passno: 0
-mount_state: "mounted"
-mount_device_identifier: "uuid"  # uuid|label|user
+mount_device_identifier: "uuid"  # uuid|label|path
 
 # luks encryption
 luks: false

--- a/tasks/disklabel-default.yml
+++ b/tasks/disklabel-default.yml
@@ -1,0 +1,11 @@
+---
+
+# TODO: Choose a disklabel type based on platform and disk size.
+#
+- name: Create disklabels as needed
+  parted:
+    device: "{{ item }}"
+    label: "gpt"
+    state: "{{ state }}"
+  when: use_partitions and device_type != 'disk'
+  with_items: "{{ disk_paths }}"

--- a/tasks/fs-default.yml
+++ b/tasks/fs-default.yml
@@ -1,0 +1,14 @@
+---
+- name: Stat the final device file
+  include_tasks: stat_device.yml
+
+- name: Remove file system as needed
+  shell: wipefs {{ fs_destroy_options }} {{ device_path }}
+  when: fs_type == "" or state == "absent" and device_status.stat.exists
+
+- name: Create filesystem as needed
+  filesystem:
+    dev: "{{ device_path }}"
+    fstype: "{{ fs_type }}"
+    opts: "{{ fs_create_options }}"
+  when: fs_type != "" and state == "present" and device_status.stat.exists

--- a/tasks/lv-default.yml
+++ b/tasks/lv-default.yml
@@ -1,0 +1,10 @@
+---
+- name: Make sure LV exists
+  lvol:
+    lv: "{{ device_name }}"
+    vg: "{{ lvm_vg }}"
+    size: "{{ size }}"
+    state: "{{ state }}"
+    force: yes
+    shrink: no
+  when: device_type == "lvm" and lvm_vg != ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,84 +1,60 @@
 ---
 
 # TODO: Argument validation.
-# TODO: Figure out how to update defaults as needed based on args, eg: lv name from mount point
+#
+# TODO: Set defaults as needed: lvm_vg, device_name, disks
 
 #
-#- name: Resolve the device
-#  resolve_blockdev:
-#    spec: "{{ device }}"
-#  register: resolved  # resolved.device is the device node path
-
+# Resolve specified disks to device node paths.
+#
 - name: Resolve disks
   resolve_blockdev:
     spec: "{{ item }}"
   with_items: "{{ disks }}"
   register: resolved_disks
 
+- debug: var=resolved_disks
+
+- set_fact:
+    disk_paths: "{{ resolved_disks.results|map(attribute='device')|list }}"
+
 - name: Show disks
   debug:
-    var: resolved_disks
+    var: disk_paths
 
-- name: Create disklabels as needed
-  debug:
-    msg: "Creating {{ partition_table_type }} partition table on {{ item.device }}"
-  when: use_partitions and device_type != 'disk'
-  with_items: "{{ resolved_disks.results }}"
-
-# See if the vg exists.
-#   If so, see if the lv exists.
-#     If so, move on to encryption and fs.
-#     Else create it.
-#   Else create pv(s), then vg.
 #
-# TODO: Figure out how to get the name of the new partition.
-# TODO: Figure out how to determine partition disk(s) and size(s).
-- name: Create partition if needed
-  debug:
-    msg: "Creating partition of size {{ size }} on {{ resolved_disks.results[0]['device'] }}"
-  when: (use_partitions and device_type != 'disk') or device_type == "partition"
+# Set the path for the final device based on device type.
+#
+- set_fact:
+    device_path: "{{ disk_paths[0] }}"
+  when: device_type == "disk"
 
-# TODO: Make sure lvm_vg is defined and non-empty.
-- name: Make sure VG exists if needed
-  lvg:
-    vg: "{{ lvm_vg }}"
-    pvs: "{{resolved_disks.results|join(',', attribute='device')}}"
-    pesize: "{{ lvm_extent_size }}"
-  when: device_type == "lvm" and false
-
-- name: Make sure VG exists
-  debug:
-    msg: "running lvg with name {{ lvm_vg }} and pvs [{{resolved_disks.results|join(',', attribute='device')}}]"
+- set_fact:
+    device_path: "/dev/mapper/{{ lvm_vg }}-{{ device_name }}"
   when: device_type == "lvm"
 
-- name: Make sure LV exists
-  #lvol:
-  #  lv: "{{ device_name }}"
-  #  vg: "{{ lvm_vg }}"
-  debug:
-    msg: "running lvol with name {{ device_name }} and size {{ size }} in vg {{ lvm_vg }}"
-  when: device_type == "lvm"
+- debug: var=device_path
 
-# TODO: Get the device node path. Could be disk, partition, luks, lvm, md, vdo.
 
-- name: Create filesystem as needed
-  #filesystem:
-  #  dev: "{{device}}"
-  #  fstype: "{{ fs_type }}"
-  #  opts: "{{ fs_create_options }}"
-  debug:
-    msg: "Creating {{ fs_type }} on {{ device_name }}"
-  when: fs_type != ""
+- name: Remove the Specified Storage Volume
+  include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
+  with_items: "{{ storage_layers[::-1] }}"
+  loop_control:
+    loop_var: layer
+  when: state == "absent"
 
-# Set up the mount using a stable device identifier.
-- name: Set up the mount
-  #mount:
-  #  src: "{{ device }}"
-  #  path: "{{ mount_point }}"
-  #  fstype: "{{ fs_type }}"
-  #  opts: "{{ mount_options }}"
-  #  state: "{{ mount_state }}"
-  debug:
-    msg: "Adding mount entry for {{ device_name }} on {{ mount_point }} as {{ fs_type }} using {{ mount_device_identifier }}"
-  when: mount_point != ""
 
+- name: Configure the Specified Storage Volume
+  include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
+  with_items: "{{ storage_layers }}"
+  loop_control:
+    loop_var: layer
+  when: state == "present"
+
+#
+# Update facts since we may have changed system state.
+#
+# Should this be in a handler instead?
+#
+- name: Update facts
+  setup:

--- a/tasks/mount-default.yml
+++ b/tasks/mount-default.yml
@@ -1,0 +1,29 @@
+---
+- name: Stat the final device file
+  include_tasks: stat_device.yml
+
+# TODO: set the mount device identifier correctly
+- set_fact:
+    mount_device_id: "{{ device_path }}"
+  when: mount_device_identifier == "path"
+
+- name: Collect file system UUID
+  block:
+    - shell: blkid -s UUID -o value {{ device_path }}
+      register: blkid_output
+    - set_fact:
+        mount_device_id: "UUID=\"{{ blkid_output.stdout }}\""
+  rescue:
+    - set_fact:
+        mount_device_id: "{{ device_path }}"
+  when: mount_device_identifier == "uuid" and device_status.stat.exists
+
+# Set up the mount using a stable device identifier.
+- name: Set up the mount
+  mount:
+    src: "{{ device_path }}"
+    path: "{{ mount_point }}"
+    fstype: "{{ fs_type }}"
+    opts: "{{ mount_options }}"
+    state: "{{ state }}"
+  when: mount_point != "" and device_path != ""

--- a/tasks/mount-default.yml
+++ b/tasks/mount-default.yml
@@ -18,6 +18,17 @@
         mount_device_id: "{{ device_path }}"
   when: mount_device_identifier == "uuid" and device_status.stat.exists
 
+#
+# Activate configured mounts.
+#
+- set_fact:
+    mount_state: "{{ state }}"
+  when: state != "present"
+
+- set_fact:
+    mount_state: "mounted"
+  when: state == "present"
+
 # Set up the mount using a stable device identifier.
 - name: Set up the mount
   mount:

--- a/tasks/mount-default.yml
+++ b/tasks/mount-default.yml
@@ -36,5 +36,5 @@
     path: "{{ mount_point }}"
     fstype: "{{ fs_type }}"
     opts: "{{ mount_options }}"
-    state: "{{ state }}"
+    state: "{{ mount_state }}"
   when: mount_point != "" and device_path != ""

--- a/tasks/partitions-default.yml
+++ b/tasks/partitions-default.yml
@@ -1,0 +1,8 @@
+---
+
+# TODO: Figure out how to get the name of the new partition.
+# TODO: Figure out how to determine partition disk(s) and size(s).
+#- name: Create partition if needed
+#  debug:
+#    msg: "Creating partition of size {{ size }} on {{ disk_paths[0] }}"
+#  when: (use_partitions and device_type != 'disk') or device_type == "partition"

--- a/tasks/stat_device.yml
+++ b/tasks/stat_device.yml
@@ -1,0 +1,4 @@
+---
+- name: Stat the final device file
+  stat: path={{ device_path }}
+  register: device_status

--- a/tasks/vg-default.yml
+++ b/tasks/vg-default.yml
@@ -44,7 +44,6 @@
 
 - set_fact:
     remove_vg: false
-  when: device_type != "lvm" or state == "present" or ansible_check_mode
 
 - set_fact:
     remove_vg: true

--- a/tasks/vg-default.yml
+++ b/tasks/vg-default.yml
@@ -43,12 +43,12 @@
   when: device_type == "lvm" and state == "absent"
 
 - set_fact:
-    remove_vg: lvs_cmd.stdout == ""
-  when: device_type == "lvm" and state == "absent" and not ansible_check_mode
-
-- set_fact:
     remove_vg: false
   when: device_type != "lvm" or state == "present" or ansible_check_mode
+
+- set_fact:
+    remove_vg: true
+  when: device_type == "lvm" and state == "absent" and not ansible_check_mode and lvs_cmd.stdout == ""
 
 #
 # Configure the VG
@@ -66,8 +66,12 @@
   when: device_type == "lvm" and lvm_vg != "" and (state == "present" or remove_vg)
 
 - name: Wipe VG metadata as needed
-  shell: pvremove {{ pv_path }}
-  with_items: "{{ pvs }}"
-  loop_control:
-    loop_var: pv_path
+  block:
+   - shell: pvremove {{ pv_path }}
+     with_items: "{{ pvs }}"
+     loop_control:
+       loop_var: pv_path
+  rescue:
+    - debug:
+        msg: "Failed to wipe pv signatures."
   when: remove_vg

--- a/tasks/vg-default.yml
+++ b/tasks/vg-default.yml
@@ -1,0 +1,73 @@
+---
+#
+# Set the list of PV devices.
+#
+# TODO: Decide on semantics. Playbook PV specs should probably be complete to enable idempotency.
+#
+- name: Get current PVs
+  block:
+    - shell: pvs -o name --noheadings --select 'vg_name={{ lvm_vg }}'
+      register: pvs_cmd
+      become: true
+  rescue:
+    - debug:
+        msg: "Failed to run pvs"
+  when: disks == [] and device_type == "lvm" and lvm_vg in ansible_facts.lvm.vgs
+
+- set_fact:
+    pvs: "{{ disk_paths }}"
+  when: device_type == "lvm"
+
+- set_fact:
+    pvs: "{{ pvs_cmd.stdout.split() }}"
+  when: disks == [] and device_type == "lvm" and lvm_vg in ansible_facts.lvm.vgs
+
+- set_fact:
+    pvs: "{{ pvs|unique }}"
+  when: device_type == "lvm"
+
+
+#
+# Get list of LVs.
+#
+# We will only remove VG if there are no more LVs and state is "absent".
+#
+- name: Get current LVs
+  block:
+    - shell: lvs -o name --noheadings --select 'vg_name={{ lvm_vg }}'
+      register: lvs_cmd
+      become: true
+  rescue:
+    - debug:
+        msg: "Failed to run lvs"
+  when: device_type == "lvm" and state == "absent"
+
+- set_fact:
+    remove_vg: lvs_cmd.stdout == ""
+  when: device_type == "lvm" and state == "absent" and not ansible_check_mode
+
+- set_fact:
+    remove_vg: false
+  when: device_type != "lvm" or state == "present" or ansible_check_mode
+
+#
+# Configure the VG
+#
+- name: Make sure VG exists if needed
+  block:
+    - lvg:
+        vg: "{{ lvm_vg }}"
+        pvs: "{{ pvs }}"
+        #pesize: "{{ lvm_extent_size }}"
+        state: "{{ state }}"
+  rescue:
+    - debug:
+        msg: "Failed to configure vg"
+  when: device_type == "lvm" and lvm_vg != "" and (state == "present" or remove_vg)
+
+- name: Wipe VG metadata as needed
+  shell: pvremove {{ pv_path }}
+  with_items: "{{ pvs }}"
+  loop_control:
+    loop_var: pv_path
+  when: remove_vg

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,36 @@
 ---
 - hosts: localhost
-  remote_user: root
+  become: true
+
   roles:
-    - template
+#    - { role: ../linux-storage-role, "disks": ["vdb"], mount_point: '/opt/test1', device_name: 'test1', lvm_vg: 'foo', size: '5g'}
+#    - { role: ../linux-storage-role, "disks": ["vdb"], mount_point: '/opt/test2', device_name: 'test2', lvm_vg: 'foo'}
+#    - { role: ../linux-storage-role, "disks": ["vdc"], mount_point: '/opt/test3', device_type: 'disk'}
+  tasks:
+    - include_role:
+        name: ../linux-storage-role
+      vars:
+        device_name: 'test1'
+        disks: ['vdb']
+        lvm_vg: 'foo'
+        mount_point: '/opt/test1'
+        size: '5g'
+        #state: 'absent'
+
+    - include_role:
+        name: ../linux-storage-role
+      vars:
+        device_name: 'test2'
+        disks: ['vdb']
+        fs_type: 'ext4'
+        lvm_vg: 'foo'
+        mount_point: '/opt/test2'
+        #state: 'absent'
+
+    - include_role:
+        name: ../linux-storage-role
+      vars:
+        device_type: 'disk'
+        disks: ['vdc']
+        mount_point: '/opt/test3'
+        #state: 'absent'


### PR DESCRIPTION
Tasks are grouped by layer, eg: lv, vg, partition, fs. This allows us to reverse the order when removing stacks as well as to reuse tasks for layers that can be inserted at various points in the stack like luks.

There's also a fair amount more fleshing out of the overall logic. I've now done some testing of lvm-on-unpartitioned-disk stacks including mounts, both creation and removal. I'm sure there are still issues, but the overall flow seems to be in place.