### PR TITLE
Install lvm2 package commands before running role

### DIFF
--- a/tasks/install-default.yml
+++ b/tasks/install-default.yml
@@ -2,15 +2,8 @@
 
 # See: https://github.com/ansible/ansible/issues/30518
 
-- name: Check if lvm rpm package is installed
-  command: rpm -q lvm2
-  changed_when: no
-  args:
-    warn: no
-  register: rpm_lvm_check
-
 - name: Install LVM2 commands for RedHat OS
   package:
     pkg: lvm2
     state: present
-  when: rpm_lvm_check.rc == 1
+  when: device_type == 'lvm' or device_type == ''

--- a/tasks/install-default.yml
+++ b/tasks/install-default.yml
@@ -1,0 +1,16 @@
+---
+
+# See: https://github.com/ansible/ansible/issues/30518
+
+- name: Check if lvm rpm package is installed
+  command: rpm -q lvm2
+  changed_when: no
+  args:
+    warn: no
+  register: rpm_lvm_check
+
+- name: Install LVM2 commands for RedHat OS
+  package:
+    pkg: lvm2
+    state: present
+  when: rpm_lvm_check.rc == 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,9 @@
 #
 # Resolve specified disks to device node paths.
 #
+
+- include_tasks: "install-default.yml"
+
 - name: Resolve disks
   resolve_blockdev:
     spec: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,6 @@
 #
 # TODO: Set defaults as needed: lvm_vg, device_name, disks
 
-- include_tasks: "install-default.yml"
-
 #
 # Resolve specified disks to device node paths.
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
 #
 # TODO: Set defaults as needed: lvm_vg, device_name, disks
 
+- include_tasks: "install-default.yml"
+
 #
 # Resolve specified disks to device node paths.
 #

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,8 +7,6 @@
 #    - { role: ../linux-storage-role, "disks": ["vdb"], mount_point: '/opt/test2', device_name: 'test2', lvm_vg: 'foo'}
 #    - { role: ../linux-storage-role, "disks": ["vdc"], mount_point: '/opt/test3', device_type: 'disk'}
   tasks:
-    - include: "../tasks/install-default.yml"
-
     - include_role:
         name: ../linux-storage-role
       vars:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,6 +7,8 @@
 #    - { role: ../linux-storage-role, "disks": ["vdb"], mount_point: '/opt/test2', device_name: 'test2', lvm_vg: 'foo'}
 #    - { role: ../linux-storage-role, "disks": ["vdc"], mount_point: '/opt/test3', device_type: 'disk'}
   tasks:
+    - include: "../tasks/install-default.yml"
+
     - include_role:
         name: ../linux-storage-role
       vars:


### PR DESCRIPTION
- Installs the lvm2 package using the ansible package module. 
- Ran this in Fedora28 and RHEL 7 and didn't need to start the lvm2 service after installation for the rest of the playbook to run uninterrupted. 