### PR TITLE
[RFC] Initialize LVM variable names when undefined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,4 @@ mount_device_identifier: "uuid"  # uuid|label|path
 
 # lvm
 lvm_vg: ""  # TODO: Select a good default. Hostname?
+use_existing_vg: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,30 +7,31 @@
 #
 # Resolve specified disks to device node paths.
 #
-# - name: Resolve disks
-#   resolve_blockdev:
-#     spec: "{{ item }}"
-#   with_items: "{{ disks }}"
-#   register: resolved_disks
-#
-# - debug: var=resolved_disks
-#
-# - set_fact:
-#     disk_paths: "{{ resolved_disks.results|map(attribute='device')|list }}"
-#
-# - name: Show disks
-#   debug:
-#     var: disk_paths
+
+- name: Resolve disks
+  resolve_blockdev:
+    spec: "{{ item }}"
+  with_items: "{{ disks }}"
+  register: resolved_disks
+
+- debug: var=resolved_disks
+
+- set_fact:
+    disk_paths: "{{ resolved_disks.results|map(attribute='device')|list }}"
+
+- name: Show disks
+  debug:
+    var: disk_paths
 
 #
 # Setup lvm variable names when undefined
 #
-- name: Generate device name
+- name: Generate LVM variable names as needed
   lvm_gensym:
     mount: "{{ mount_point }}"
     fs_type: "{{ fs_type }}"
     size: "{{ size }}"
-    default_mode: "{{ use_existing_vg }}"
+    find_vg: "{{ use_existing_vg }}"
   when: device_type== "lvm" and device_name == ""
   register: gensym_results
 
@@ -43,38 +44,38 @@
   when: device_type == "lvm" and lvm_vg == "" and use_existing_vg
 
 - debug: var=gensym_results
-# #
-# # Set the path for the final device based on device type.
-# #
-# - set_fact:
-#     device_path: "{{ disk_paths[0] }}"
-#   when: device_type == "disk"
 #
-# - set_fact:
-#     device_path: "/dev/mapper/{{ lvm_vg }}-{{ device_name }}"
-#   when: device_type == "lvm"
+# Set the path for the final device based on device type.
 #
-# - debug: var=device_path
+- set_fact:
+    device_path: "{{ disk_paths[0] }}"
+  when: device_type == "disk"
+
+- set_fact:
+    device_path: "/dev/mapper/{{ lvm_vg }}-{{ device_name }}"
+  when: device_type == "lvm"
+
+- debug: var=device_path
+
+- name: Remove the Specified Storage Volume
+  include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
+  with_items: "{{ storage_layers[::-1] }}"
+  loop_control:
+    loop_var: layer
+  when: state == "absent"
+
+
+- name: Configure the Specified Storage Volume
+  include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
+  with_items: "{{ storage_layers }}"
+  loop_control:
+    loop_var: layer
+  when: state == "present"
+
 #
-# - name: Remove the Specified Storage Volume
-#   include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
-#   with_items: "{{ storage_layers[::-1] }}"
-#   loop_control:
-#     loop_var: layer
-#   when: state == "absent"
+# Update facts since we may have changed system state.
 #
+# Should this be in a handler instead?
 #
-# - name: Configure the Specified Storage Volume
-#   include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
-#   with_items: "{{ storage_layers }}"
-#   loop_control:
-#     loop_var: layer
-#   when: state == "present"
-#
-# #
-# # Update facts since we may have changed system state.
-# #
-# # Should this be in a handler instead?
-# #
-# - name: Update facts
-#   setup:
+- name: Update facts
+  setup:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,20 +7,20 @@
 #
 # Resolve specified disks to device node paths.
 #
-- name: Resolve disks
-  resolve_blockdev:
-    spec: "{{ item }}"
-  with_items: "{{ disks }}"
-  register: resolved_disks
-
-- debug: var=resolved_disks
-
-- set_fact:
-    disk_paths: "{{ resolved_disks.results|map(attribute='device')|list }}"
-
-- name: Show disks
-  debug:
-    var: disk_paths
+# - name: Resolve disks
+#   resolve_blockdev:
+#     spec: "{{ item }}"
+#   with_items: "{{ disks }}"
+#   register: resolved_disks
+#
+# - debug: var=resolved_disks
+#
+# - set_fact:
+#     disk_paths: "{{ resolved_disks.results|map(attribute='device')|list }}"
+#
+# - name: Show disks
+#   debug:
+#     var: disk_paths
 
 #
 # Setup lvm variable names when undefined
@@ -29,6 +29,8 @@
   lvm_gensym:
     mount: "{{ mount_point }}"
     fs_type: "{{ fs_type }}"
+    size: "{{ size }}"
+    default_mode: "{{ use_existing_vg }}"
   when: device_type== "lvm" and device_name == ""
   register: gensym_results
 
@@ -36,40 +38,43 @@
     device_name: "{{ gensym_results.lv_name }}"
   when: device_type == "lvm" and device_name == ""
 
-- debug: var=device_name
-
-#
-# Set the path for the final device based on device type.
-#
 - set_fact:
-    device_path: "{{ disk_paths[0] }}"
-  when: device_type == "disk"
+    lvm_vg: "{{ gensym_results.vg_name }}"
+  when: device_type == "lvm" and lvm_vg == "" and use_existing_vg
 
-- set_fact:
-    device_path: "/dev/mapper/{{ lvm_vg }}-{{ device_name }}"
-  when: device_type == "lvm"
-
-- debug: var=device_path
-
-- name: Remove the Specified Storage Volume
-  include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
-  with_items: "{{ storage_layers[::-1] }}"
-  loop_control:
-    loop_var: layer
-  when: state == "absent"
-
-
-- name: Configure the Specified Storage Volume
-  include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
-  with_items: "{{ storage_layers }}"
-  loop_control:
-    loop_var: layer
-  when: state == "present"
-
+- debug: var=gensym_results
+# #
+# # Set the path for the final device based on device type.
+# #
+# - set_fact:
+#     device_path: "{{ disk_paths[0] }}"
+#   when: device_type == "disk"
 #
-# Update facts since we may have changed system state.
+# - set_fact:
+#     device_path: "/dev/mapper/{{ lvm_vg }}-{{ device_name }}"
+#   when: device_type == "lvm"
 #
-# Should this be in a handler instead?
+# - debug: var=device_path
 #
-- name: Update facts
-  setup:
+# - name: Remove the Specified Storage Volume
+#   include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
+#   with_items: "{{ storage_layers[::-1] }}"
+#   loop_control:
+#     loop_var: layer
+#   when: state == "absent"
+#
+#
+# - name: Configure the Specified Storage Volume
+#   include_tasks: "{{ layer }}-{{ storage_backend }}.yml"
+#   with_items: "{{ storage_layers }}"
+#   loop_control:
+#     loop_var: layer
+#   when: state == "present"
+#
+# #
+# # Update facts since we may have changed system state.
+# #
+# # Should this be in a handler instead?
+# #
+# - name: Update facts
+#   setup:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,22 @@
     var: disk_paths
 
 #
+# Setup lvm variable names when undefined
+#
+- name: Generate device name
+  lvm_gensym:
+    mount: "{{ mount_point }}"
+    fs_type: "{{ fs_type }}"
+  when: device_type== "lvm" and device_name == ""
+  register: gensym_results
+
+- set_fact:
+    device_name: "{{ gensym_results.lv_name }}"
+  when: device_type == "lvm" and device_name == ""
+
+- debug: var=device_name
+
+#
 # Set the path for the final device based on device type.
 #
 - set_fact:
@@ -34,7 +50,6 @@
   when: device_type == "lvm"
 
 - debug: var=device_path
-
 
 - name: Remove the Specified Storage Volume
   include_tasks: "{{ layer }}-{{ storage_backend }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
     fs_type: "{{ fs_type }}"
     size: "{{ size }}"
     find_vg: "{{ use_existing_vg }}"
-  when: device_type== "lvm" and device_name == ""
+  when: device_type== "lvm"
   register: gensym_results
 
 - set_fact:
@@ -41,7 +41,7 @@
 
 - set_fact:
     lvm_vg: "{{ gensym_results.vg_name }}"
-  when: device_type == "lvm" and lvm_vg == "" and use_existing_vg
+  when: device_type == "lvm" and lvm_vg == ""
 
 - debug: var=gensym_results
 #

--- a/tests/unit/gensym_test.py
+++ b/tests/unit/gensym_test.py
@@ -50,8 +50,8 @@ def test_vg_eval(monkeypatch, os_name):
     vg_names = [os_name + "_user", os_name + "_user_0", os_name + "_user_1"]
     _lvm_facts = dict(vgs=dict.fromkeys(vg_names), lvs=dict())
     monkeypatch.setattr(lvm_gensym, "get_os_name", get_os_name)
-    assert lvm_gensym.get_vg_name('user', _lvm_facts) == os_name + '_user_2'
-    assert lvm_gensym.get_vg_name('', _lvm_facts) == os_name
+    assert lvm_gensym.get_default_vg_name('user', _lvm_facts) == os_name + '_user_2'
+    assert lvm_gensym.get_default_vg_name('', _lvm_facts) == os_name
 
 def test_lv_eval():
     """Test the generated unique logical volume name against the expected name"""


### PR DESCRIPTION
- library/lvm_gensym/py now checks if there's free space available in existing volume groups if the user specified in the playbook they want this behavior. If the user failed to define a variable name for the 'lvm_vg' variable, and didn't specify they wanted to use an existing VG, then the lvm_gensym module will create a new VG name.
- The return value on the 'get_existing_vg_name' function needs to be changed, but I wan't able to find anything on error handling in Ansible modules without explicitly adding another parameter to that function.