### PR TITLE
Update module_utils/size.py to handle sizes without byte suffixes

### DIFF
--- a/module_utils/size.py
+++ b/module_utils/size.py
@@ -47,9 +47,13 @@ class Size(object):
         '''
 
         prefix = raw_units
+        no_suffix_flag = True
+        valid_suffix = False
+
         # get rid of possible units suffix ('bytes', 'b' or 'B')
         for suffix in SUFFIXES:
             if raw_units.lower().endswith(suffix.lower()):
+                no_suffix_flag = False
                 prefix = raw_units[:-len(suffix)]
                 break
 
@@ -63,19 +67,24 @@ class Size(object):
         for lst in PREFIXES_DECIMAL:
             lower_lst = [x.lower() for x in lst]
             if prefix.lower() in lower_lst:
+                valid_suffix = True
                 idx = lower_lst.index(prefix.lower())
                 used_factor = DECIMAL_FACTOR
                 break
 
-        if idx < 0:
+        if idx < 0 or no_suffix_flag:
+            if no_suffix_flag:
+                used_factor = BINARY_FACTOR
+
             for lst in PREFIXES_BINARY:
                 lower_lst = [x.lower() for x in lst]
                 if prefix.lower() in lower_lst:
+                    valid_suffix = True
                     idx = lower_lst.index(prefix.lower())
                     used_factor = BINARY_FACTOR
                     break
 
-        if idx < 0:
+        if idx < 0 or not valid_suffix:
             raise ValueError("Unable to identify unit '%s'" % raw_units)
 
         return used_factor, idx+1
@@ -149,4 +158,3 @@ class Size(object):
             value = (float(self.factor ** self.exponent) / float(ftr ** exp)) * self.number
 
         return self._format(fmt, ftr, exp) % value
-

--- a/tests/unit/bsize_test.py
+++ b/tests/unit/bsize_test.py
@@ -27,3 +27,8 @@ def test_bsize():
 
     # check string to bytes conversion
     assert Size("1.2 terabyte").bytes == 1.2e12
+
+    # check string without byte prefix gets converted to binary
+    assert Size("5g").get() == "5.0 GiB"
+
+    assert Size("5gb").get() == "4.7 GiB"


### PR DESCRIPTION
- Before, if a user specified the size as `size: '5g'`, size.py would interpret this as a decimal value instead of binary.
- Currently,  the `valid_suffix` flag will raise an error if used entered `size: '100%FREE'` 